### PR TITLE
TCPShield v2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ configurations {
     testImplementation.extendsFrom compileOnly
 }
 
-version = '2.0'
+version = '2.1'
 group = 'net.tcpshield.tcpshield'
 archivesBaseName = 'TCPShield'
 

--- a/src/main/java/net/tcpshield/tcpshield/HandshakePacketHandler.java
+++ b/src/main/java/net/tcpshield/tcpshield/HandshakePacketHandler.java
@@ -92,7 +92,7 @@ public class HandshakePacketHandler {
     private void handleInvalidTimestamp(IPlayer player, long timestamp, long currentTime) {
         if (config.isDebug()) {
             this.logger.warning(String.format("%s[%s/%s] provided valid handshake information, but timestamp was not valid. " +
-                    "Provided timestamp: %d vs. system timestamp: %d. Please check your machine time.", player.getName(), player.getUUID(), player.getIP(), timestamp, currentTime));
+                    "Provided timestamp: %d vs. system timestamp: %d. Please check your machine time. Timestamp validation mode: %s", player.getName(), player.getUUID(), player.getIP(), timestamp, currentTime, config.getTimestampValidationMode()));
         }
 
         if (config.isOnlyProxy()) {

--- a/src/main/java/net/tcpshield/tcpshield/ReflectionUtils.java
+++ b/src/main/java/net/tcpshield/tcpshield/ReflectionUtils.java
@@ -58,7 +58,18 @@ public class ReflectionUtils {
         Field cachedField = CACHED_FIELDS.get(clazz, fieldName);
         if (cachedField != null) return cachedField;
 
-        Field field = clazz.getDeclaredField(fieldName);
+        Field field;
+        try {
+            field = clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            Class<?> superclass = clazz.getSuperclass();
+            if (superclass != null) {
+                return getDeclaredField(superclass, fieldName);
+            } else {
+                throw e;
+            }
+        }
+
         CACHED_FIELDS.put(clazz, fieldName, field);
         return field;
     }

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/TCPShieldBukkit.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/TCPShieldBukkit.java
@@ -16,6 +16,8 @@ public class TCPShieldBukkit extends JavaPlugin {
     }
 
     private boolean isPaper() {
+        if (true) return false; // disabled for now
+
         try {
             Class.forName("com.destroystokyo.paper.event.player.PlayerHandshakeEvent");
             return true;

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/paper/impl/PaperPlayerImpl.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/paper/impl/PaperPlayerImpl.java
@@ -39,6 +39,7 @@ public class PaperPlayerImpl implements IPlayer {
 
     @Override
     public void disconnect() {
+        handshakeEvent.setCancelled(false);
         handshakeEvent.setFailMessage("Connection failed. Please try again or contract an administrator.");
         handshakeEvent.setFailed(true);
     }

--- a/src/main/java/net/tcpshield/tcpshield/velocity/VelocityHandshakePacketHandler.java
+++ b/src/main/java/net/tcpshield/tcpshield/velocity/VelocityHandshakePacketHandler.java
@@ -3,11 +3,9 @@ package net.tcpshield.tcpshield.velocity;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.ConnectionHandshakeEvent;
 import com.velocitypowered.api.event.proxy.ProxyPingEvent;
-import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.InboundConnection;
 import net.tcpshield.tcpshield.HandshakePacketHandler;
 import net.tcpshield.tcpshield.abstraction.IPacket;
-import net.tcpshield.tcpshield.abstraction.IPlayer;
 import net.tcpshield.tcpshield.velocity.impl.VelocityConfigImpl;
 import net.tcpshield.tcpshield.velocity.impl.VelocityPacketImpl;
 import net.tcpshield.tcpshield.velocity.impl.VelocityPlayerImpl;
@@ -36,9 +34,8 @@ public class VelocityHandshakePacketHandler {
     }
 
     private void handleEvent(InboundConnection connection) {
-        IPlayer player = new VelocityPlayerImpl(connection);
-        ProtocolVersion protocolVersion = connection.getProtocolVersion();
-        if (protocolVersion.isLegacy() || protocolVersion.isUnknown()) {
+        VelocityPlayerImpl player = new VelocityPlayerImpl(connection);
+        if (player.isLegacy()) {
             player.disconnect();
             return;
         }

--- a/src/main/java/net/tcpshield/tcpshield/velocity/VelocityHandshakePacketHandler.java
+++ b/src/main/java/net/tcpshield/tcpshield/velocity/VelocityHandshakePacketHandler.java
@@ -3,6 +3,7 @@ package net.tcpshield.tcpshield.velocity;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.ConnectionHandshakeEvent;
 import com.velocitypowered.api.event.proxy.ProxyPingEvent;
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.InboundConnection;
 import net.tcpshield.tcpshield.HandshakePacketHandler;
 import net.tcpshield.tcpshield.abstraction.IPacket;
@@ -36,6 +37,12 @@ public class VelocityHandshakePacketHandler {
 
     private void handleEvent(InboundConnection connection) {
         IPlayer player = new VelocityPlayerImpl(connection);
+        ProtocolVersion protocolVersion = connection.getProtocolVersion();
+        if (protocolVersion.isLegacy() || protocolVersion.isUnknown()) {
+            player.disconnect();
+            return;
+        }
+
         IPacket packet = new VelocityPacketImpl(connection);
 
         handshakePacketHandler.onHandshake(packet, player);

--- a/src/main/java/net/tcpshield/tcpshield/velocity/impl/VelocityPacketImpl.java
+++ b/src/main/java/net/tcpshield/tcpshield/velocity/impl/VelocityPacketImpl.java
@@ -11,11 +11,15 @@ public class VelocityPacketImpl implements IPacket {
 
     private static final Field HANDSHAKE_FIELD;
     private static final Field HOSTNAME_FIELD;
+    private static final Field CLEANED_ADDRESS_FIELD;
 
     static {
         try {
-            HANDSHAKE_FIELD = ReflectionUtils.getPrivateField(Class.forName("com.velocitypowered.proxy.connection.client.InitialInboundConnection"), "handshake");
+            Class<?> inboundConnection = Class.forName("com.velocitypowered.proxy.connection.client.InitialInboundConnection");
+
+            HANDSHAKE_FIELD = ReflectionUtils.getPrivateField(inboundConnection, "handshake");
             HOSTNAME_FIELD = ReflectionUtils.getPrivateField(Class.forName("com.velocitypowered.proxy.protocol.packet.Handshake"), "serverAddress");
+            CLEANED_ADDRESS_FIELD = ReflectionUtils.getPrivateField(inboundConnection, "cleanedAddress");
         } catch (NoSuchFieldException | ClassNotFoundException e) {
             throw new TCPShieldInitializationException(e);
         }
@@ -40,6 +44,8 @@ public class VelocityPacketImpl implements IPacket {
 
     @Override
     public void modifyOriginalPacket(String hostname) throws Exception {
+        ReflectionUtils.setFinalField(inboundConnection, CLEANED_ADDRESS_FIELD, hostname);
+
         Object handshake = HANDSHAKE_FIELD.get(inboundConnection);
         HOSTNAME_FIELD.set(handshake, hostname);
     }

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: TCPShield
-version: '2.0'
+version: '2.1'
 main: net.tcpshield.tcpshield.bungee.TCPShieldBungee
 author: https://tcpshield.com

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: '2.0'
+version: '2.1'
 main: net.tcpshield.tcpshield.bukkit.TCPShieldBukkit
 softdepend:
 - ProtocolLib


### PR DESCRIPTION
- fixes for the Velocity implementation
-> fixed error messages on legacy pings
-> fixed `forced-hosts` feature
- temporarily disables native Paper support because of disfunctions
- adds the timestamp validation mode to the debug message 