### PR TITLE
Adjusts event priority

### DIFF
--- a/src/main/java/net/tcpshield/tcpshield/bukkit/paper/PaperHandshakePacketHandler.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/paper/PaperHandshakePacketHandler.java
@@ -23,7 +23,7 @@ public class PaperHandshakePacketHandler implements Listener {
         this.handshakePacketHandler = new HandshakePacketHandler(plugin.getLogger(), new BukkitConfigImpl(plugin));
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onHandshake(PlayerHandshakeEvent e) {
         IPacket packet = new PaperPacketImpl(e);
         IPlayer player = new PaperPlayerImpl(e);
@@ -31,7 +31,7 @@ public class PaperHandshakePacketHandler implements Listener {
         handshakePacketHandler.onHandshake(packet, player);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onServerPing(PaperServerListPingEvent e) {
         if (e.getClient().isLegacy()) e.setCancelled(true);
 

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/protocollib/ProtocolLibHandshakePacketHandler.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/protocollib/ProtocolLibHandshakePacketHandler.java
@@ -17,7 +17,7 @@ public class ProtocolLibHandshakePacketHandler extends PacketAdapter {
     private final HandshakePacketHandler handshakePacketHandler;
 
     public ProtocolLibHandshakePacketHandler(JavaPlugin plugin) {
-        super(plugin, ListenerPriority.HIGHEST, PacketType.Handshake.Client.SET_PROTOCOL);
+        super(plugin, ListenerPriority.LOWEST, PacketType.Handshake.Client.SET_PROTOCOL);
         this.handshakePacketHandler = new HandshakePacketHandler(plugin.getLogger(), new BukkitConfigImpl(plugin));
     }
 

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/protocollib/impl/ProtocolLibPlayerImpl.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/protocollib/impl/ProtocolLibPlayerImpl.java
@@ -8,14 +8,11 @@ import net.tcpshield.tcpshield.exception.IPModificationFailureException;
 import net.tcpshield.tcpshield.exception.TCPShieldInitializationException;
 import org.bukkit.entity.Player;
 
-import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 public class ProtocolLibPlayerImpl implements IPlayer {
 
-    private static Field socketAddressField;
-    private static Field remoteAddressField;
     private static Class<?> abstractChannelClass;
     private final Player player;
     private String ip;


### PR DESCRIPTION
This could fix a bug where people using ViaVersion's protocol translator aren't assigned their real IP sometimes. Due to the nature of TCPShield, it's important that we get called *first*. `EventPriority.LOWEST` or `ListenerPriority.LOWEST` get called first.