### PR TITLE
Remove Legacy API

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,4 @@ main: net.tcpshield.tcpshield.bukkit.TCPShieldBukkit
 softdepend:
 - ProtocolLib
 author: https://tcpshield.com
+api-version: 1.16


### PR DESCRIPTION
Set api-version in plugin.yml so 1.13+ servers won't have to load the **incredibly** slow legacy compatibility layer.

This still works with versions older than 1.13.