### PR TITLE
Fixed Bukkit Config Loading and ProtocolLib Implementation

### DIFF
--- a/src/main/java/net/tcpshield/tcpshield/bukkit/BukkitConfig.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/BukkitConfig.java
@@ -54,7 +54,7 @@ public class BukkitConfig extends ConfigProvider {
 				// Just ignore since it either does not exist, or we can overwrite
 			}
 
-			try (InputStream in = BukkitConfig.class.getResourceAsStream("config.yml")) {
+			try (InputStream in = plugin.getResource("config.yml")) { // Have to use Bukkit's resource streaming or the resource wont be found
 				Files.copy(in, configFile.toPath());
 			}
 		} catch (Exception e) {

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/TCPShieldBukkit.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/TCPShieldBukkit.java
@@ -31,8 +31,14 @@ public class TCPShieldBukkit extends JavaPlugin implements TCPShieldPlugin {
 
 			if (BukkitImplProvider.hasPaperEvent())
 				bukkitImpl = new BukkitPaper(this);
-			else
+			else {
+				if (getServer().getPluginManager().getPlugin("ProtocolLib") == null) {
+					getLogger().severe("TCPShield not loading because ProtocolLib is not installed. Either use Paper to enable native compatibility or install ProtocolLib.");
+					return;
+				}
+
 				bukkitImpl = new BukkitProtocolLib(this);
+			}
 
 			bukkitImpl.load();
 		} catch (Exception e) {

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/protocollib/BukkitProtocolLib.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/protocollib/BukkitProtocolLib.java
@@ -16,11 +16,6 @@ public class BukkitProtocolLib extends BukkitImplProvider {
 
 	@Override
 	public void load() {
-		if (getPlugin().getServer().getPluginManager().getPlugin("ProtocolLib") == null) {
-			getPlugin().getLogger().severe("TCPShield not loading because ProtocolLib is not installed. Either use Paper to enable native compatibility or install ProtocolLib.");
-			return;
-		}
-
 		ProtocolLibHandshakeHandler packetHandler = new ProtocolLibHandshakeHandler(this);
 		com.comphenix.protocol.ProtocolLibrary.getProtocolManager().addPacketListener(packetHandler);
 	}


### PR DESCRIPTION
Changed resource streaming for the Bukkit implementation of the config to Bukkit's resource streamer. Also fixed an issue with the ProtocolLib implementation where it throws an error instead of warning and disabling when ProtocolLib is not installed.