### PR TITLE
fix tcpshield not kicking players joining via otherways

### DIFF
--- a/src/main/java/net/tcpshield/tcpshield/bukkit/paper/handler/PaperPlayer.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/paper/handler/PaperPlayer.java
@@ -57,6 +57,7 @@ public class PaperPlayer implements PlayerProvider {
 
 	@Override
 	public void disconnect() {
+		handshakeEvent.setCancelled(false);
 		handshakeEvent.setFailMessage("Connection failed. Please try again or contract an administrator.");
 		handshakeEvent.setFailed(true);
 	}


### PR DESCRIPTION
Players werent being kicked when they joined with the actual server ip and port which resulted in errors like #49 and possible also #53 (it might also be that for some reason the debugger of this issues has been set to true) not sure or there are issues related to this.   

I experienced this problem on git-Purpur-1166 and also have tested this only on this version, not sure about other effects this will have for different versions but in 2.4 the code also was this so i dont expect any major problems. 

fix #49