### PR TITLE
Adds description option in plugin.yml to support Bukkit 1.17

### DIFF
--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -2,3 +2,4 @@ name: TCPShield
 version: '2.5'
 main: net.tcpshield.tcpshield.bungee.TCPShieldBungee
 author: https://tcpshield.com
+description: "TCPShield IP parsing capabilities for Bungee"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,8 @@
-name: TCPShield
+name: "TCPShield"
 version: '2.5'
-main: net.tcpshield.tcpshield.bukkit.TCPShieldBukkit
+main: "net.tcpshield.tcpshield.bukkit.TCPShieldBukkit"
 softdepend:
-- ProtocolLib
-author: https://tcpshield.com
+  - ProtocolLib
+author: "https://tcpshield.com"
+description: "TCPShield IP parsing capabilities for Bukkit"
 api-version: 1.16

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,13 +1,11 @@
 {
-  "id":"tcpshield",
-  "name":"TCPShield",
-  "version":"2.5",
-  "description":"TCPShield IP parsing capabilities for Velocity",
-  "authors":[
+  "id": "tcpshield",
+  "name": "TCPShield",
+  "version": "2.5",
+  "description": "TCPShield IP parsing capabilities for Velocity",
+  "authors": [
     "TCPShield"
   ],
-  "dependencies":[
-
-  ],
-  "main":"net.tcpshield.tcpshield.velocity.TCPShieldVelocity"
+  "dependencies": [],
+  "main": "net.tcpshield.tcpshield.velocity.TCPShieldVelocity"
 }


### PR DESCRIPTION
As of Bukkit 1.17, plugins are required to include a `description` option in their plugin.yml to properly initialize. I added this option in the plugin.yml so it can properly load on 1.17+ servers.